### PR TITLE
Add query to span at end of trace

### DIFF
--- a/pkg/ocgorm/callbacks.go
+++ b/pkg/ocgorm/callbacks.go
@@ -165,6 +165,11 @@ func (c *callbacks) endTrace(scope *gorm.Scope) {
 		return
 	}
 
+	// Add query to the span if requested
+	if c.query {
+		span.AddAttributes(trace.StringAttribute(QueryAttribute, scope.SQL))
+	}
+
 	var status trace.Status
 
 	if scope.HasError() {


### PR DESCRIPTION
Queries don't seem to be generated at the beginning of trace which is called at "before gorm:query" callback. They are available during "after gorm:query" callback. Hence, instrumenting it then also. 

This same PR is opened upstream https://github.com/sagikazarmark/go-gin-gorm-opencensus/pull/8 but has not had any response yet. I am thinking of merging these fixes here and use them in cloud repos.