### PR TITLE
modify: implement datadogs expected tags

### DIFF
--- a/pkg/ocgorm/callbacks.go
+++ b/pkg/ocgorm/callbacks.go
@@ -146,7 +146,7 @@ func (c *callbacks) startTrace(ctx context.Context, scope *gorm.Scope, operation
 	)
 
 	if c.query {
-		attributes = append(attributes, trace.StringAttribute(QueryAttribute, scope.SQL))
+		attributes = append(attributes, trace.StringAttribute(ResourceNameAttribute, scope.SQL))
 	}
 
 	span.AddAttributes(attributes...)
@@ -169,7 +169,7 @@ func (c *callbacks) endTrace(scope *gorm.Scope) {
 
 	// Add query to the span if requested
 	if c.query {
-		span.AddAttributes(trace.StringAttribute(QueryAttribute, scope.SQL))
+		span.AddAttributes(trace.StringAttribute(ResourceNameAttribute, scope.SQL))
 	}
 
 	var status trace.Status
@@ -210,13 +210,13 @@ func (c *callbacks) endStats(scope *gorm.Scope) {
 	stats.Record(ctx, QueryCount.M(1))
 }
 
-func (c *callbacks) beforeCreate(scope *gorm.Scope) { c.before(scope, "create") }
-func (c *callbacks) afterCreate(scope *gorm.Scope)  { c.after(scope) }
-func (c *callbacks) beforeQuery(scope *gorm.Scope)  { c.before(scope, "query") }
-func (c *callbacks) afterQuery(scope *gorm.Scope)   { c.after(scope) }
-func (c *callbacks) beforeRowQuery(scope *gorm.Scope)  { c.before(scope, "row_query") }
-func (c *callbacks) afterRowQuery(scope *gorm.Scope)   { c.after(scope) }
-func (c *callbacks) beforeUpdate(scope *gorm.Scope) { c.before(scope, "update") }
-func (c *callbacks) afterUpdate(scope *gorm.Scope)  { c.after(scope) }
-func (c *callbacks) beforeDelete(scope *gorm.Scope) { c.before(scope, "delete") }
-func (c *callbacks) afterDelete(scope *gorm.Scope)  { c.after(scope) }
+func (c *callbacks) beforeCreate(scope *gorm.Scope)   { c.before(scope, "create") }
+func (c *callbacks) afterCreate(scope *gorm.Scope)    { c.after(scope) }
+func (c *callbacks) beforeQuery(scope *gorm.Scope)    { c.before(scope, "query") }
+func (c *callbacks) afterQuery(scope *gorm.Scope)     { c.after(scope) }
+func (c *callbacks) beforeRowQuery(scope *gorm.Scope) { c.before(scope, "row_query") }
+func (c *callbacks) afterRowQuery(scope *gorm.Scope)  { c.after(scope) }
+func (c *callbacks) beforeUpdate(scope *gorm.Scope)   { c.before(scope, "update") }
+func (c *callbacks) afterUpdate(scope *gorm.Scope)    { c.after(scope) }
+func (c *callbacks) beforeDelete(scope *gorm.Scope)   { c.before(scope, "delete") }
+func (c *callbacks) afterDelete(scope *gorm.Scope)    { c.after(scope) }

--- a/pkg/ocgorm/trace.go
+++ b/pkg/ocgorm/trace.go
@@ -2,6 +2,10 @@ package ocgorm
 
 // Attributes recorded on the span for the queries.
 const (
-	QueryAttribute = "gorm.query"
+	// Datadog expects the query text here to enable aggregations of queries
+	// Must be used in tandem with a service.name and span.type attribute
+	// Our fork uses this instead of gorm.query
+	ResourceNameAttribute = "resource.name"
+
 	TableAttribute = "gorm.table"
 )


### PR DESCRIPTION
I've modified the span tagging structure to comply with what datadog expects upon ingestion to enable aggregation.

This enables part of what [RFC SRE-007](https://docs.google.com/document/d/17E2KczHafjF7g8ybFvK0r86Ip3tPIqq5OgradQDAwL0/edit#) discusses. It's been tested in PRDE, see screenshots linked in associated [cloud-sdk PR](https://github.com/hashicorp/cloud-sdk/pull/523) for what this enables.