### PR TITLE
fix: you need both build directives if you target both sides of the 1.18 upgrade

### DIFF
--- a/pkg/ocgorm/stats.go
+++ b/pkg/ocgorm/stats.go
@@ -1,4 +1,5 @@
 //go:build go1.11
+// +build go1.11
 
 package ocgorm
 


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/go-gin-gorm-opencensus/pull/4