### PR TITLE
F rename package fork diverged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
 # Project variables
-PACKAGE = github.com/sagikazarmark/go-gin-gorm-opencensus
+PACKAGE = github.com/hashicorp/go-gin-gorm-opencensus
 BINARY_NAME = go-gin-gorm-opencensus
 
 # Build variables

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Go OpenCensus example for Gin and Gorm
 
 [![Build Status](https://img.shields.io/travis/com/sagikazarmark/go-gin-gorm-opencensus.svg?style=flat-square)](https://travis-ci.com/sagikazarmark/go-gin-gorm-opencensus)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sagikazarmark/go-gin-gorm-opencensus?style=flat-square)](https://goreportcard.com/report/github.com/sagikazarmark/go-gin-gorm-opencensus)
-[![GolangCI](https://golangci.com/badges/github.com/sagikazarmark/go-gin-gorm-opencensus.svg)](https://golangci.com/r/github.com/sagikazarmark/go-gin-gorm-opencensus)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/go-gin-gorm-opencensus?style=flat-square)](https://goreportcard.com/report/github.com/hashicorp/go-gin-gorm-opencensus)
+[![GolangCI](https://golangci.com/badges/github.com/hashicorp/go-gin-gorm-opencensus.svg)](https://golangci.com/r/github.com/hashicorp/go-gin-gorm-opencensus)
 
 This repository serves as an example for configuring [OpenCensus](http://opencensus.io/) to
 instrument applications written using [Gin](https://gin-gonic.github.io/gin/) framework

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sagikazarmark/go-gin-gorm-opencensus
+module github.com/hashicorp/go-gin-gorm-opencensus
 
 go 1.12
 
@@ -10,7 +10,6 @@ require (
 	github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 // indirect
 	github.com/gin-gonic/gin v1.3.0
 	github.com/go-sql-driver/mysql v1.4.0 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jinzhu/gorm v1.9.1
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
 	github.com/jinzhu/now v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,14 +100,12 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
-github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJDADN2ufcGik7W992pyps0wZ888b/y9GXcLTU=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0 h1:kUZDBDTdBVBYBj5Tmh2NZLlF60mfjA27rM34b+cVwNU=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFdaDqxJVlbOQ1DtGmZWs/Qau0hIlk+WQ=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
@@ -121,7 +119,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go v1.1.1 h1:gmervu+jDMvXTbcHQ0pd2wee85nEoE0BsVyEuzkfK8w=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
-go.opencensus.io v0.20.1 h1:pMEjRZ1M4ebWGikflH7nQpV6+Zr88KBMA2XJD3sbijw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -145,7 +142,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -158,7 +154,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -167,7 +162,6 @@ golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-google.golang.org/api v0.3.1 h1:oJra/lMfmtm13/rgY/8i3MzjFWYXvQIAKjQ3HqofMk8=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.3.2 h1:iTp+3yyl/KOtxa/d1/JUE0GGSoR6FuW5udver22iwpw=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
@@ -180,7 +174,6 @@ google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRn
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -190,7 +183,6 @@ gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8
 gopkg.in/go-playground/validator.v8 v8.18.2 h1:lFB4DoMU6B626w8ny76MV7VX6W2VHct2GVOI3xgiMrQ=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/actions.go
+++ b/internal/actions.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/hashicorp/go-gin-gorm-opencensus/pkg/ocgorm"
 	"github.com/jinzhu/gorm"
-	"github.com/sagikazarmark/go-gin-gorm-opencensus/pkg/ocgorm"
 )
 
 type NewPerson struct {

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 
-	"github.com/sagikazarmark/go-gin-gorm-opencensus/internal"
-	"github.com/sagikazarmark/go-gin-gorm-opencensus/pkg/ocgorm"
+	"github.com/hashicorp/go-gin-gorm-opencensus/internal"
+	"github.com/hashicorp/go-gin-gorm-opencensus/pkg/ocgorm"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 		ochttp.ServerResponseCountByStatusCode,
 
 		// Gorm stats
-		ocgorm.QueryCountView,
+		ocgorm.SQLClientCallsView,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/ocgorm/callbacks.go
+++ b/pkg/ocgorm/callbacks.go
@@ -97,7 +97,6 @@ func RegisterCallbacks(db *gorm.DB, opts ...Option) {
 	db.Callback().Update().After("gorm:update").Register("instrumentation:after_update", c.afterUpdate)
 	db.Callback().Delete().Before("gorm:delete").Register("instrumentation:before_delete", c.beforeDelete)
 	db.Callback().Delete().After("gorm:delete").Register("instrumentation:after_delete", c.afterDelete)
-	fmt.Println("all callbacks registered")
 }
 
 func (c *callbacks) before(scope *gorm.Scope, operation string) {
@@ -197,7 +196,6 @@ var (
 )
 
 func (c *callbacks) startStats(ctx context.Context, scope *gorm.Scope, operation string) context.Context {
-	fmt.Println("running startStats")
 	ctx, _ = tag.New(ctx,
 		tag.Upsert(Operation, operation),
 		tag.Upsert(Table, scope.TableName()),
@@ -208,36 +206,29 @@ func (c *callbacks) startStats(ctx context.Context, scope *gorm.Scope, operation
 }
 
 func (c *callbacks) endStats(scope *gorm.Scope) {
-	fmt.Println("running endStats")
 	if scope.HasError() {
 		return
 	}
 
-	fmt.Println("getting scope")
 	rctx, _ := scope.Get(contextScopeKey)
 	ctx, ok := rctx.(context.Context)
 	if !ok || ctx == nil {
 		return
 	}
-	fmt.Println("got scope")
 
 	tags := tag.FromContext(ctx)
 	ctx, _ = tag.New(ctx, tag.Delete(queryStartPropagator))
 	queryStartNS, exists := tags.Value(queryStartPropagator)
-	fmt.Println("propagator tag fetched")
 
 	if exists {
-		fmt.Println("propagator tag exists")
 		queryStart, err := time.Parse(time.RFC3339Nano, queryStartNS)
 		if err != nil {
-			fmt.Println("failed to parse timestamp")
 			return
 		}
 
 		timeSpentMs := float64(time.Since(queryStart).Nanoseconds()) / 1e6
 
 		stats.Record(ctx, MeasureLatencyMs.M(timeSpentMs))
-		fmt.Println("successfully recorded")
 	}
 
 	stats.Record(ctx, MeasureQueryCount.M(1))

--- a/pkg/ocgorm/stats.go
+++ b/pkg/ocgorm/stats.go
@@ -26,7 +26,7 @@ var (
 
 // Measures
 var (
-	MeasureQueryCount        = stats.Int64("go.sql/client/query_count", "Number of queries started", stats.UnitDimensionless)
+	MeasureQueryCount        = stats.Int64("go.sql/client/calls", "Number of queries started", stats.UnitDimensionless)
 	MeasureLatencyMs         = stats.Float64("go.sql/client/latency", "The latency of calls in milliseconds", stats.UnitMilliseconds)
 	MeasureOpenConnections   = stats.Int64("go.sql/connections/open", "Count of open connections in the pool", stats.UnitDimensionless)
 	MeasureIdleConnections   = stats.Int64("go.sql/connections/idle", "Count of idle connections in the pool", stats.UnitDimensionless)
@@ -74,9 +74,17 @@ var (
 )
 
 var (
-	QueryCountView = &view.View{
-		Name:        "go.sql/client/query_count",
-		Description: "Count of queries started",
+	SQLClientLatencyView = &view.View{
+		Name:        "go.sql/client/latency",
+		Description: "The distribution of latencies of various calls in milliseconds",
+		Measure:     MeasureLatencyMs,
+		Aggregation: DefaultMillisecondsDistribution,
+		TagKeys:     []tag.Key{Operation, Table},
+	}
+
+	SQLClientCallsView = &view.View{
+		Name:        "go.sql/client/calls",
+		Description: "The number of various calls of methods",
 		Measure:     MeasureQueryCount,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{Operation, Table},
@@ -139,7 +147,7 @@ var (
 	}
 
 	DefaultViews = []*view.View{
-		SQLClientOpenConnectionsView,
+		SQLClientCallsView, SQLClientLatencyView, SQLClientOpenConnectionsView,
 		SQLClientIdleConnectionsView, SQLClientActiveConnectionsView,
 		SQLClientWaitCountView, SQLClientWaitDurationView,
 		SQLClientIdleClosedView, SQLClientLifetimeClosedView,

--- a/pkg/ocgorm/stats.go
+++ b/pkg/ocgorm/stats.go
@@ -5,6 +5,7 @@ package ocgorm
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,16 +18,16 @@ import (
 // Tags applied to measures
 var (
 	// Operation is the type of query (SELECT, INSERT, UPDATE, DELETE)
-	Operation, _ = tag.NewKey("gorm.operation")
+	Operation, _ = tag.NewKey("sql.operation")
 
 	// Table name of the target database table
-	Table, _ = tag.NewKey("gorm.table")
+	Table, _ = tag.NewKey("sql.table")
 )
 
 // Measures
 var (
-	QueryCount               = stats.Int64("opencensus.io/gorm/query_count", "Number of queries started", stats.UnitDimensionless)
-	MeasureLatencyMs         = stats.Float64("go.sql/latency", "The latency of calls in milliseconds", stats.UnitMilliseconds)
+	MeasureQueryCount        = stats.Int64("go.sql/client/query_count", "Number of queries started", stats.UnitDimensionless)
+	MeasureLatencyMs         = stats.Float64("go.sql/client/latency", "The latency of calls in milliseconds", stats.UnitMilliseconds)
 	MeasureOpenConnections   = stats.Int64("go.sql/connections/open", "Count of open connections in the pool", stats.UnitDimensionless)
 	MeasureIdleConnections   = stats.Int64("go.sql/connections/idle", "Count of idle connections in the pool", stats.UnitDimensionless)
 	MeasureActiveConnections = stats.Int64("go.sql/connections/active", "Count of active connections in the pool", stats.UnitDimensionless)
@@ -74,11 +75,11 @@ var (
 
 var (
 	QueryCountView = &view.View{
-		Name:        "opencensus.io/gorm/query_count",
+		Name:        "go.sql/client/query_count",
 		Description: "Count of queries started",
-		TagKeys:     []tag.Key{Operation, Table},
-		Measure:     QueryCount,
+		Measure:     MeasureQueryCount,
 		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{Operation, Table},
 	}
 
 	SQLClientOpenConnectionsView = &view.View{
@@ -168,6 +169,14 @@ func RecordStats(db *gorm.DB, interval time.Duration) (fnStop func()) {
 			select {
 			case <-ticker.C:
 				dbStats := db.DB().Stats()
+
+				if dbStats.OpenConnections == 0 { // We cleanup the ticker in the event that the database is unavailable
+					if err := db.DB().Ping(); strings.Contains(err.Error(), "database is closed") {
+						ticker.Stop()
+						return
+					}
+				}
+
 				stats.Record(ctx,
 					MeasureOpenConnections.M(int64(dbStats.OpenConnections)),
 					MeasureIdleConnections.M(int64(dbStats.Idle)),


### PR DESCRIPTION
The package has sufficiently diverged from upstream that we now use it under our own namespace, this enables consumers of cloud-sdk to get updates implicitly via the indirect dependency cloud-sdk introduces rather than pushing the burden onto services to keep up to date with both this package and cloud-sdk.

The package now emits latency and call count metrics for operations, giving us a long term retained metric path that can be monitored for general database performance.
Additionally the ticker cleans itself up now, to prevent a potential memory leak.
