### PR TITLE
Add support to custom tags on RecordStats and Gorm v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,8 @@ require (
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/go-sql-driver/mysql v1.4.0 // indirect
 	github.com/jinzhu/gorm v1.9.1
-	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
-	github.com/jinzhu/now v1.0.0 // indirect
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	go.opencensus.io v0.21.0
+	gorm.io/gorm v1.24.5
 )

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,10 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jinzhu/gorm v1.9.1 h1:lDSDtsCt5AGGSKTs8AHlSDbbgif4G4+CKJ8ETBDVHTA=
 github.com/jinzhu/gorm v1.9.1/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
-github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a h1:eeaG9XMUvRBYXJi4pg1ZKM7nxc5AfXfojeLLW7O5J3k=
-github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.0.0 h1:6WV8LvwPpDhKjo5U9O6b4+xdG/jTXNPwlDme/MTo8Ns=
-github.com/jinzhu/now v1.0.0/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.4 h1:tHnRBy1i5F2Dh8BAFxqFzxKqqvezXrL2OW1TnX+Mlas=
+github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -132,6 +132,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gorm.io/gorm v1.24.5 h1:g6OPREKqqlWq4kh/3MCQbZKImeB9e6Xgc4zD+JgNZGE=
+gorm.io/gorm v1.24.5/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/ocgorm/stats.go
+++ b/pkg/ocgorm/stats.go
@@ -164,7 +164,7 @@ func RegisterAllViews() {
 // RecordStats records database statistics for provided sql.DB at the provided
 // interval. You should defer execution of this function after you establish
 // connection to the database `if err == nil { ocgorm.RecordStats(db, 5*time.Second); }
-func RecordStats(db *gorm.DB, interval time.Duration) (fnStop func()) {
+func RecordStats(db *gorm.DB, interval time.Duration, tags ...tag.Mutator) (fnStop func()) {
 	var (
 		closeOnce sync.Once
 		ctx       = context.Background()
@@ -185,7 +185,8 @@ func RecordStats(db *gorm.DB, interval time.Duration) (fnStop func()) {
 					}
 				}
 
-				stats.Record(ctx,
+				stats.RecordWithTags(ctx,
+					tags,
 					MeasureOpenConnections.M(int64(dbStats.OpenConnections)),
 					MeasureIdleConnections.M(int64(dbStats.Idle)),
 					MeasureActiveConnections.M(int64(dbStats.InUse)),

--- a/pkg/ocgormv2/context.go
+++ b/pkg/ocgormv2/context.go
@@ -1,0 +1,17 @@
+package ocgormv2
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Gorm scope key
+var (
+	contextScopeKey = "_opencensusContext"
+
+
+// WithContext sets the current context in the db instance for instrumentation.
+func WithContext(ctx context.Context, db *gorm.DB) *gorm.DB {
+	return db.New().Set(contextScopeKey, ctx)
+}

--- a/pkg/ocgormv2/stats.go
+++ b/pkg/ocgormv2/stats.go
@@ -1,0 +1,69 @@
+//go:build go1.11
+// +build go1.11
+
+package ocgormv2
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-gin-gorm-opencensus/pkg/ocgorm"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"gorm.io/gorm"
+)
+
+// RecordStats records database statistics for provided sql.DB at the provided
+// interval. You should defer execution of this function after you establish
+// connection to the database `if err == nil { ocgorm.RecordStats(db, 5*time.Second); }
+func RecordStats(db *gorm.DB, interval time.Duration, tags ...tag.Mutator) (fnStop func()) {
+	var (
+		closeOnce sync.Once
+		ctx       = context.Background()
+		ticker    = time.NewTicker(interval)
+		done      = make(chan struct{})
+	)
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				sqlDB, err := db.DB()
+				if err != nil {
+					continue
+				}
+
+				dbStats := sqlDB.Stats()
+
+				if dbStats.OpenConnections == 0 { // We cleanup the ticker in the event that the database is unavailable
+					if err := sqlDB.Ping(); strings.Contains(err.Error(), "database is closed") {
+						ticker.Stop()
+						return
+					}
+				}
+
+				stats.RecordWithTags(ctx,
+					tags,
+					ocgorm.MeasureOpenConnections.M(int64(dbStats.OpenConnections)),
+					ocgorm.MeasureIdleConnections.M(int64(dbStats.Idle)),
+					ocgorm.MeasureActiveConnections.M(int64(dbStats.InUse)),
+					ocgorm.MeasureWaitCount.M(dbStats.WaitCount),
+					ocgorm.MeasureWaitDuration.M(float64(dbStats.WaitDuration.Nanoseconds())/1e6),
+					ocgorm.MeasureIdleClosed.M(dbStats.MaxIdleClosed),
+					ocgorm.MeasureLifetimeClosed.M(dbStats.MaxLifetimeClosed),
+				)
+			case <-done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return func() {
+		closeOnce.Do(func() {
+			close(done)
+		})
+	}
+}


### PR DESCRIPTION
This tries to add support for tags on the `RecordStats` function.
The motivation here is to [for example](https://github.com/hashicorp/cloud-sdk/pull/621) support "read-only" and "read-write" replica tags.

This also creates a `ocgormv2` package, that uses the main gorm repo, instead of the old v1.
This could help unblock people moving forward with their gorm version.