### PR TITLE
Change the type of "total*" metrics

### DIFF
--- a/pkg/ocgorm/stats.go
+++ b/pkg/ocgorm/stats.go
@@ -118,7 +118,7 @@ var (
 		Name:        "go.sql/db/connections/wait_count",
 		Description: "The total number of connections waited for",
 		Measure:     MeasureWaitCount,
-		Aggregation: view.LastValue(),
+		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{},
 	}
 
@@ -126,7 +126,7 @@ var (
 		Name:        "go.sql/db/connections/wait_duration",
 		Description: "The total time blocked waiting for a new connection",
 		Measure:     MeasureWaitDuration,
-		Aggregation: view.LastValue(),
+		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{},
 	}
 
@@ -134,7 +134,7 @@ var (
 		Name:        "go.sql/db/connections/idle_closed_count",
 		Description: "The total number of connections closed due to SetMaxIdleConns",
 		Measure:     MeasureIdleClosed,
-		Aggregation: view.LastValue(),
+		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{},
 	}
 
@@ -142,7 +142,7 @@ var (
 		Name:        "go.sql/db/connections/lifetime_closed_count",
 		Description: "The total number of connections closed due to SetConnMaxLifetime",
 		Measure:     MeasureLifetimeClosed,
-		Aggregation: view.LastValue(),
+		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{},
 	}
 


### PR DESCRIPTION
`DBStats` exposes metrics whose definition imply it being a counter. For example, "wait_count" is defined as "total number of connections waited for" which means that during the process run the value emitted by this stat will keep increasing. This is evident by looking at the db pool source. Hence, it should be registered as a "Count" metric instead of Gauge which implies a fixed value at a point in time unrelated to previous values.