### PR TITLE
Add DB name to all pool stats

### DIFF
--- a/pkg/ocgormv2/stats.go
+++ b/pkg/ocgormv2/stats.go
@@ -5,6 +5,7 @@ package ocgormv2
 
 import (
 	"context"
+	"go.opencensus.io/tag"
 	"strings"
 	"sync"
 	"time"
@@ -30,7 +31,7 @@ func RegisterAllViews() {
 // RecordStats records database statistics for provided sql.DB at the provided
 // interval. You should defer execution of this function after you establish
 // connection to the database `if err == nil { ocgorm.RecordStats(db, 5*time.Second); }
-func RecordStats(db *gorm.DB, interval time.Duration) (fnStop func()) {
+func RecordStats(db *gorm.DB, interval time.Duration, name string) (fnStop func()) {
 	var (
 		closeOnce sync.Once
 		ctx       = context.Background()
@@ -55,7 +56,8 @@ func RecordStats(db *gorm.DB, interval time.Duration) (fnStop func()) {
 					}
 				}
 
-				stats.Record(ctx,
+				stats.RecordWithTags(ctx,
+					[]tag.Mutator{tag.Upsert(ocgorm.DatabaseName, name)},
 					ocgorm.MeasureOpenConnections.M(int64(dbStats.OpenConnections)),
 					ocgorm.MeasureIdleConnections.M(int64(dbStats.Idle)),
 					ocgorm.MeasureActiveConnections.M(int64(dbStats.InUse)),


### PR DESCRIPTION
Add DB name to pool stats since services can have multiple `sql.DB` object and calling `RecordStats` on each of them clobber each other giving incorrect information. For example, resource-manager has 3 instances: one gorm v1 object instantiated by cloud-sdk, another gorm v2 writer and another gorm v2 reader.

Since this is breaking change, I will bring it in cloud-sdk after merging. As of now only cloud-resource-manager and cloud-vagrant-box-registry are directly calling this function. I'll update both after updating cloud-sdk.

Here is an example of metrics after making this change:
```
➜ curl localhost:8080/metrics | grep go_sql_db_
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12074    0 12074    0     0  18124      0 --:--:-- --:--:-- --:--:-- 18101# HELP go_sql_db_connections_active The number of active connections
# TYPE go_sql_db_connections_active gauge
go_sql_db_connections_active{database_name="resource-manager-reader",service="cloud-resource-manager"} 0
go_sql_db_connections_active{database_name="resource-manager-writer",service="cloud-resource-manager"} 0
go_sql_db_connections_active{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 0
# HELP go_sql_db_connections_idle The number of idle connections
# TYPE go_sql_db_connections_idle gauge
go_sql_db_connections_idle{database_name="resource-manager-reader",service="cloud-resource-manager"} 10
go_sql_db_connections_idle{database_name="resource-manager-writer",service="cloud-resource-manager"} 1
go_sql_db_connections_idle{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 1
# HELP go_sql_db_connections_idle_closed_count The total number of connections closed due to SetMaxIdleConns
# TYPE go_sql_db_connections_idle_closed_count gauge
go_sql_db_connections_idle_closed_count{database_name="resource-manager-reader",service="cloud-resource-manager"} 0
go_sql_db_connections_idle_closed_count{database_name="resource-manager-writer",service="cloud-resource-manager"} 0
go_sql_db_connections_idle_closed_count{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 0
# HELP go_sql_db_connections_lifetime_closed_count The total number of connections closed due to SetConnMaxLifetime
# TYPE go_sql_db_connections_lifetime_closed_count gauge
go_sql_db_connections_lifetime_closed_count{database_name="resource-manager-reader",service="cloud-resource-manager"} 0
go_sql_db_connections_lifetime_closed_count{database_name="resource-manager-writer",service="cloud-resource-manager"} 0
go_sql_db_connections_lifetime_closed_count{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 0
# HELP go_sql_db_connections_open The number of open connections
# TYPE go_sql_db_connections_open gauge
go_sql_db_connections_open{database_name="resource-manager-reader",service="cloud-resource-manager"} 10
go_sql_db_connections_open{database_name="resource-manager-writer",service="cloud-resource-manager"} 1
go_sql_db_connections_open{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 1
# HELP go_sql_db_connections_wait_count The total number of connections waited for
# TYPE go_sql_db_connections_wait_count gauge
go_sql_db_connections_wait_count{database_name="resource-manager-reader",service="cloud-resource-manager"} 9
go_sql_db_connections_wait_count{database_name="resource-manager-writer",service="cloud-resource-manager"} 0
go_sql_db_connections_wait_count{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 0
# HELP go_sql_db_connections_wait_duration The total time blocked waiting for a new connection
# TYPE go_sql_db_connections_wait_duration gauge
go_sql_db_connections_wait_duration{database_name="resource-manager-reader",service="cloud-resource-manager"} 4.420356
go_sql_db_connections_wait_duration{database_name="resource-manager-writer",service="cloud-resource-manager"} 0
go_sql_db_connections_wait_duration{database_name="resource-manager-writer-v2",service="cloud-resource-manager"} 0
100 82930    0 82930    0     0  96501      0 --:--:-- --:--:-- --:--:-- 96430
```